### PR TITLE
Fix response not containing gap_limit

### DIFF
--- a/blockchain/blockexplorer.py
+++ b/blockchain/blockexplorer.py
@@ -322,7 +322,7 @@ class Xpub:
         self.final_balance = xpub['final_balance']
         self.change_index = xpub['change_index']
         self.account_index = xpub['account_index']
-        self.gap_limit = xpub['gap_limit']
+        self.gap_limit = xpup.get('gap_limit', None)
         self.transactions = [Transaction(tx) for tx in a['txs']]
 
 

--- a/blockchain/blockexplorer.py
+++ b/blockchain/blockexplorer.py
@@ -322,7 +322,7 @@ class Xpub:
         self.final_balance = xpub['final_balance']
         self.change_index = xpub['change_index']
         self.account_index = xpub['account_index']
-        self.gap_limit = xpup.get('gap_limit', None)
+        self.gap_limit = xpub.get('gap_limit', None)
         self.transactions = [Transaction(tx) for tx in a['txs']]
 
 


### PR DESCRIPTION
Fixes

```  File "/home/oskar/PycharmProjects/Transaction2/clients/blockchain_info.py", line 117, in xpub_balance
    unspent = blockexplorer.get_xpub(xpub)
  File "/usr/local/lib/python3.6/dist-packages/blockchain/blockexplorer.py", line 112, in get_xpub
    return Xpub(json_response)
  File "/usr/local/lib/python3.6/dist-packages/blockchain/blockexplorer.py", line 325, in __init__
    self.gap_limit = xpub['gap_limit']
KeyError: 'gap_limit'```